### PR TITLE
feat(matrix): utilize matrix datapath between HBL2 and CUTE

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -261,7 +261,9 @@ object CUTE extends ScalaModule with HasChisel {
 
   def utilityModule: ScalaModule = utility
 
-  override def moduleDeps = super.moduleDeps ++ Seq(rocketModule, utilityModule)
+  def coupledL2Module: ScalaModule = coupledL2
+
+  override def moduleDeps = super.moduleDeps ++ Seq(rocketModule, utilityModule, coupledL2Module)
 }
 
 // extends this trait to use XiangShan in other projects

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -37,7 +37,7 @@ import huancun._
 import coupledL2._
 import coupledL2.prefetch._
 import amewrapper.{AMEConfigKey, AMEParams}
-import cute.{CuteParamsKey, CuteParams}
+import cute.{CuteParamsKey, CuteParams, CuteDebugParams}
 
 class BaseConfig(n: Int) extends Config((site, here, up) => {
   case XLen => 64
@@ -268,7 +268,9 @@ class MinimalMatrixConfig(n: Int) extends Config(
       dataWidth = 32,
       matrixSize = 16
     )
-    case CuteParamsKey => CuteParams.CUTE_8Tops_128SCP
+    case CuteParamsKey => CuteParams.CUTE_8Tops_128SCP.copy(
+        Debug = CuteDebugParams.AllDebugOn
+    )
   })
 )
 

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -270,9 +270,15 @@ class XSTile()(implicit p: Parameters) extends LazyModule
     cuteOpt.foreach { case cute =>
       l2top.module.io.matrixDataOut512L2 := DontCare
       cute.module.io := DontCare
-      cute.module.io.ctrl2top.amuCtrl <> amuCtrlArbiter.io.out
-      core.module.io.amuRelease.bits := cute.module.io.ctrl2top.mrelease.bits
-      core.module.io.amuRelease.valid := cute.module.io.ctrl2top.mrelease.valid
+      cute.module.io.cute.ctrl2top.amuCtrl <> amuCtrlArbiter.io.out
+      core.module.io.amuRelease.bits := cute.module.io.cute.ctrl2top.mrelease.bits
+      core.module.io.amuRelease.valid := cute.module.io.cute.ctrl2top.mrelease.valid
+
+      val matrix_data_in = cute.module.io.matrix_data_in
+      val matrix_data_out = l2top.module.io.matrixDataOut512L2
+      val matrix_data_arb = Module(new Arbiter(matrix_data_out(0).bits.cloneType, matrix_data_out.length))
+      matrix_data_arb.io.in <> matrix_data_out
+      matrix_data_in <> matrix_data_arb.io.out
     }
   }
 


### PR DESCRIPTION
- Now PUT sent by CUTE will not fail in HBL2.
- GrantData directly pass through 64B-wide channel.
- Bump CUTE:
  - Assign HBL2 required Matrix userkey in TL bundles.
  - Handle additional 64B-wide TL D channel.
- Bump coupledL2:
  - Extend sourceId bits to fit Cute2TL requirement.