### PR TITLE
fix(Makefile): track CUTE scala sources in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ TOP_V = $(RTL_DIR)/$(TOP).$(RTL_SUFFIX)
 SIM_TOP_V = $(RTL_DIR)/$(SIM_TOP).$(RTL_SUFFIX)
 JAR = $(BUILD_DIR)/xsgen.jar
 
-SCALA_FILE = $(shell find ./src/main/scala -name '*.scala')
+SCALA_DIRS = ./src/main/scala $(wildcard ./CUTE/src/main/scala)
+SCALA_FILE = $(shell find $(SCALA_DIRS) -name '*.scala')
 TEST_FILE = $(shell find ./src/test/scala -name '*.scala')
 
 MEM_GEN = ./scripts/vlsi_mem_gen


### PR DESCRIPTION
## Summary

- Make now tracks Scala sources in both `src/main/scala` and `CUTE/src/main/scala`.
- This ensures CUTE-internal Scala edits trigger rebuild of related RTL outputs.
- Added optional-directory handling to avoid parse-time `find` noise when CUTE is absent.

## Workstream And Scope

- Primary workstream: XSAI RTL flow / build orchestration
- Main paths touched:
  - `Makefile`
- Coupled areas or upstream links:
  - None; dependency-list update only

## Review Focus

- Confirm dependency tracking now covers `CUTE/src/main/scala`.
- Confirm no side effects for environments where CUTE is not initialized.