### PR TITLE
feat(hpm): Add hpmevent for CUTE

### DIFF
--- a/src/main/scala/cutewrapper/XSCuteTop.scala
+++ b/src/main/scala/cutewrapper/XSCuteTop.scala
@@ -22,6 +22,7 @@ class XSCuteTopImpl(wrapper: XSCuteTop) extends LazyModuleImp(wrapper) {
     val matrix_data_in = wrapper.cute_tl.module.io.matrix_data_in.cloneType
   })
   io.ctrl2top <> cute.io.ctrl2top
+  io.perf <> cute.io.perf
   wrapper.cute_tl.module.io.matrix_data_in <> io.matrix_data_in
   wrapper.cute_tl.module.io.mmu <> cute.io.mmu2llc
   io.mmu2llc := DontCare

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -36,6 +36,7 @@ import xiangshan.backend.trace.TraceCoreInterface
 import xiangshan.mem._
 import xiangshan.cache.mmu._
 import xiangshan.cache.mmu.TlbRequestIO
+import cute.CutePerfToCoreIO
 import scala.collection.mutable.ListBuffer
 
 abstract class XSModule(implicit val p: Parameters) extends Module
@@ -119,6 +120,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
     val dft_reset = Option.when(hasDFT)(Input(new DFTResetSignals()))
     val amuCtrl = Option.when(HasMatrixExtension)(Decoupled(new AmuCtrlIO))
     val amuRelease = Option.when(HasMatrixExtension)(Flipped(Decoupled(new AmuReleaseIO2XS)))
+    val cutePerf = Option.when(HasMatrixExtension)(Input(new CutePerfToCoreIO))
   })
 
   dontTouch(io.l2_flush_done)
@@ -204,8 +206,17 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   backend.io.perf.perfEventsLsu := memBlock.io_perf
   backend.io.perf.perfEventsHc := memBlock.io.inner_hc_perfEvents
   backend.io.perf.perfEventsBackend := DontCare
+  backend.io.perf.perfEventsMatrixBackend.foreach(_.value := 0.U)
+  backend.io.perf.perfEventsMatrixMem.foreach(_.value := 0.U)
   backend.io.perf.retiredInstr := DontCare
   backend.io.perf.ctrlInfo := DontCare
+  memBlock.io.outer_matrixPerfEvents.foreach(_.value := 0.U)
+
+  if (HasMatrixExtension && p(MatAccKey) == MatAcc.CUTE) {
+    backend.io.perf.perfEventsMatrixBackend := VecInit(io.cutePerf.get.backendEvents.map(_.asTypeOf(new PerfEvent)))
+    backend.io.perf.perfEventsMatrixMem := VecInit(io.cutePerf.get.memEvents.map(_.asTypeOf(new PerfEvent)))
+    memBlock.io.outer_matrixPerfEvents := VecInit(io.cutePerf.get.memEvents.map(_.asTypeOf(new PerfEvent)))
+  }
 
   backend.io.mem.storeDebugInfo <> memBlock.io.mem_to_ooo.storeDebugInfo
   

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -33,7 +33,7 @@ import coupledL2.tl2chi.PortIO
 import xiangshan.backend.trace.TraceCoreInterface
 import xiangshan.backend.fu.matrix._
 import xiangshan.backend.fu.matrix.Bundles._
-import cute.XSCute
+import cute.{CutePerfToCoreIO, XSCute}
 
 object MatAcc extends Enumeration {
   type MatAcc = Value
@@ -258,8 +258,13 @@ class XSTile()(implicit p: Parameters) extends LazyModule
 
       val matrix_data_out = l2top.module.io.matrixDataOut512L2
       cute.module.io.matrix_data_in <> matrix_data_out
+      core.module.io.cutePerf.foreach(_ <> cute.module.io.cute.perf)
 
       cute.module.io.hartId := io.hartId
+    }
+
+    if (HasMatrixExtension && cuteOpt.isEmpty) {
+      core.module.io.cutePerf.foreach(_ := 0.U.asTypeOf(new CutePerfToCoreIO))
     }
 
     if (!HasMatrixExtension) {

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -1096,7 +1096,21 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   val memSchedulerPerf = memScheduler.asInstanceOf[SchedulerMemImp].getPerfEvents
   val dataPathPerf = dataPath.getPerfEvents
 
-  val perfBackend  = Seq()
+  val perfBackend  = if (HasMatrixExtension && p(MatAccKey) == MatAcc.CUTE) {
+    Seq(
+      ("amu_active_cycle", io.perf.perfEventsMatrixBackend(0).value),
+      ("amu_retire", io.perf.perfEventsMatrixBackend(1).value),
+      ("amu_comp_done", io.perf.perfEventsMatrixBackend(2).value),
+      ("amu_release_done", io.perf.perfEventsMatrixBackend(3).value),
+      ("amu_mte_active", io.perf.perfEventsMatrixBackend(4).value),
+      ("amu_mma_nonfp", io.perf.perfEventsMatrixBackend(5).value),
+      ("amu_mma_fp16", io.perf.perfEventsMatrixBackend(6).value),
+      ("amu_mma_bf16", io.perf.perfEventsMatrixBackend(7).value),
+      ("amu_mma_tf32", io.perf.perfEventsMatrixBackend(8).value),
+    )
+  } else {
+    Seq()
+  }
   // Keep kunminghu-v2 backend events as a stable prefix, and append matrix-related events after it.
   val perfEventsBase = Seq(("noEvent", 0.U)) ++ ctrlBlockPerfBase ++ dataPathPerf ++
     intSchedulerPerf.take(5) ++ fpSchedulerPerf ++ vecSchedulerPerf ++

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -1081,7 +1081,8 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   pfevent.io.distribute_csr := RegNext(csrio.customCtrl.distribute_csr)
   val csrevents = pfevent.io.hpmevent.slice(8,16)
 
-  val ctrlBlockPerf    = ctrlBlock.getPerfEvents
+  val ctrlBlockPerfBase = ctrlBlock.getPerfEventsBase
+  val ctrlBlockPerfExt = ctrlBlock.getPerfEventsExt
   val intSchedulerPerf = intScheduler.asInstanceOf[SchedulerArithImp].getPerfEvents
   val fpSchedulerPerf  = fpScheduler.asInstanceOf[SchedulerArithImp].getPerfEvents
   val vecSchedulerPerf = vfScheduler.asInstanceOf[SchedulerArithImp].getPerfEvents
@@ -1096,10 +1097,13 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   val dataPathPerf = dataPath.getPerfEvents
 
   val perfBackend  = Seq()
-  // let index = 0 be no event
-  val allPerfEvents = Seq(("noEvent", 0.U)) ++ ctrlBlockPerf  ++ dataPathPerf ++
-    intSchedulerPerf ++ fpSchedulerPerf ++ vecSchedulerPerf ++ mfSchedulerPerf ++
-    memSchedulerPerf ++ perfBackend
+  // Keep kunminghu-v2 backend events as a stable prefix, and append matrix-related events after it.
+  val perfEventsBase = Seq(("noEvent", 0.U)) ++ ctrlBlockPerfBase ++ dataPathPerf ++
+    intSchedulerPerf.take(5) ++ fpSchedulerPerf ++ vecSchedulerPerf ++
+    memSchedulerPerf.take(10)
+  val perfEventsExt = ctrlBlockPerfExt ++ intSchedulerPerf.drop(5) ++ mfSchedulerPerf ++
+    memSchedulerPerf.drop(10) ++ perfBackend
+  val allPerfEvents = perfEventsBase ++ perfEventsExt
 
 
   if (printEventCoding) {

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -850,8 +850,13 @@ class CtrlBlockImp(
   io.perfInfo.ctrlInfo.fpdqFull := false.B
   io.perfInfo.ctrlInfo.lsdqFull := false.B
 
-  val perfEvents = Seq(decode, rename, dispatch, rob).flatMap(_.getPerfEvents)
+  val perfEventsBase = decode.getPerfEvents ++ rename.getPerfEventsBase ++ dispatch.getPerfEvents ++ rob.getPerfEvents
+  val perfEventsExt = rename.getPerfEventsExt
+  val perfEvents = perfEventsBase ++ perfEventsExt
   generatePerfEvent()
+
+  def getPerfEventsBase: Seq[(String, UInt)] = perfEventsBase.map(_._1).zip(io_perf.take(perfEventsBase.length)).map { case (name, perf) => (name, perf.value) }
+  def getPerfEventsExt: Seq[(String, UInt)] = perfEventsExt.map(_._1).zip(io_perf.drop(perfEventsBase.length)).map { case (name, perf) => (name, perf.value) }
 
   val criticalErrors = rob.getCriticalErrors
   generateCriticalErrors()

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -74,6 +74,8 @@ class PerfCounterIO(implicit p: Parameters) extends XSBundle {
   val perfEventsBackend   = Vec(numCSRPCntCtrl, new PerfEvent)
   val perfEventsLsu       = Vec(numCSRPCntLsu, new PerfEvent)
   val perfEventsHc        = Vec(numPCntHc * coreParams.L2NBanks + 1, new PerfEvent)
+  val perfEventsMatrixBackend = Vec(9, new PerfEvent)
+  val perfEventsMatrixMem = Vec(12, new PerfEvent)
   val retiredInstr = UInt(7.W)
   val frontendInfo = new Bundle {
     val ibufFull  = Bool()

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -868,7 +868,6 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     ("rename_stall_cycle_vec     ", inHeadValid && !io.rabCommits.isWalk && dispatchCanAcc && intFreeList.io.canAllocate && fpFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && !vecFreeList.io.canAllocate),
     ("rename_stall_cycle_v0      ", inHeadValid && !io.rabCommits.isWalk && dispatchCanAcc && intFreeList.io.canAllocate && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && vlFreeList.io.canAllocate && !v0FreeList.io.canAllocate),
     ("rename_stall_cycle_vl      ", inHeadValid && !io.rabCommits.isWalk && dispatchCanAcc && intFreeList.io.canAllocate && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && !vlFreeList.io.canAllocate),
-    ("rename_stall_cycle_mx      ", inHeadValid && !io.rabCommits.isWalk && dispatchCanAcc && intFreeList.io.canAllocate && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && !mxFreeList_io_canAllocate),
   )
   val intFlPerf = intFreeList.getPerfEvents
   val fpFlPerf = fpFreeList.getPerfEvents
@@ -876,6 +875,19 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   val v0FlPerf = v0FreeList.getPerfEvents
   val mxFlPerf = OptionWrapper(HasMatrixExtension, mxFreeList.get.getPerfEvents)
   val vlFlPerf = vlFreeList.getPerfEvents
-  val perfEvents = renamePerf ++ intFlPerf ++ fpFlPerf ++ vecFlPerf ++ v0FlPerf ++ mxFlPerf.getOrElse(Seq()) ++ vlFlPerf
+
+  val perfEventsBase = renamePerf ++ intFlPerf ++ fpFlPerf ++ vecFlPerf ++ v0FlPerf ++ vlFlPerf
+  val perfEventsExt = if (HasMatrixExtension) {
+    Seq(
+      ("rename_stall_cycle_mx      ", inHeadValid && !io.rabCommits.isWalk && dispatchCanAcc && intFreeList.io.canAllocate && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && !mxFreeList_io_canAllocate),
+    ) ++ mxFlPerf.get
+  } else {
+    Seq()
+  }
+
+  val perfEvents = perfEventsBase ++ perfEventsExt
   generatePerfEvent()
+
+  def getPerfEventsBase: Seq[(String, UInt)] = perfEventsBase.map(_._1).zip(io_perf.take(perfEventsBase.length)).map { case (name, perf) => (name, perf.value) }
+  def getPerfEventsExt: Seq[(String, UInt)] = perfEventsExt.map(_._1).zip(io_perf.drop(perfEventsBase.length)).map { case (name, perf) => (name, perf.value) }
 }

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -363,6 +363,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     val outer_beu_errors_icache = Output(new L1BusErrorUnitInfo)
     val inner_hc_perfEvents = Output(Vec(numPCntHc * coreParams.L2NBanks + 1, new PerfEvent))
     val outer_hc_perfEvents = Input(Vec(numPCntHc * coreParams.L2NBanks + 1, new PerfEvent))
+    val outer_matrixPerfEvents = Input(Vec(12, new PerfEvent))
     val outer_l2PfCtrl = Output(new PrefetchCtrlFromCore)
 
     // reset signals of frontend & backend are generated in memblock
@@ -2203,8 +2204,26 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   val perfFromPTW = perfEventsPTW.map(x => ("PTW_" + x._1, x._2))
   val perfBlock     = Seq(("ldDeqCount", ldDeqCount),
                           ("stDeqCount", stDeqCount))
+  val perfMatrix = if (HasMatrixExtension && p(MatAccKey) == MatAcc.CUTE) {
+    Seq(
+      ("amu_load_a_done", io.outer_matrixPerfEvents(0).value),
+      ("amu_load_b_done", io.outer_matrixPerfEvents(1).value),
+      ("amu_load_c_done", io.outer_matrixPerfEvents(2).value),
+      ("amu_store_done", io.outer_matrixPerfEvents(3).value),
+      ("amu_aml_active", io.outer_matrixPerfEvents(4).value),
+      ("amu_bml_active", io.outer_matrixPerfEvents(5).value),
+      ("amu_cml_load_active", io.outer_matrixPerfEvents(6).value),
+      ("amu_cml_store_active", io.outer_matrixPerfEvents(7).value),
+      ("amu_mem_rd_req", io.outer_matrixPerfEvents(8).value),
+      ("amu_mem_wr_req", io.outer_matrixPerfEvents(9).value),
+      ("amu_mem_rd_32B_req", io.outer_matrixPerfEvents(10).value),
+      ("amu_mem_wr_32B_req", io.outer_matrixPerfEvents(11).value),
+    )
+  } else {
+    Seq()
+  }
   // let index = 0 be no event
-  val allPerfEvents = Seq(("noEvent", 0.U)) ++ perfFromUnits ++ perfFromTLB ++ perfFromPTW ++ perfBlock
+  val allPerfEvents = Seq(("noEvent", 0.U)) ++ perfFromUnits ++ perfFromTLB ++ perfFromPTW ++ perfBlock ++ perfMatrix
 
   if (printEventCoding) {
     for (((name, inc), i) <- allPerfEvents.zipWithIndex) {


### PR DESCRIPTION
## WARNING

THIS FEATURE SPANS A NESTED SUBMODULE BOUNDARY.

- MERGE ORDER MUST BE INSIDE-OUT: `XSAI/CUTE` FIRST, THEN `XSAI`, THEN `xsai-env`.
- THE PARENT REPOSITORY MUST ONLY POINT TO A FETCHABLE CHILD COMMIT THAT IS ALREADY MERGED OR OTHERWISE STABLE ON THE CHILD REMOTE.
- DO NOT MERGE THE `XSAI` PR WHILE ITS `CUTE` GITLINK STILL POINTS TO A LOCAL-ONLY OR PR-ONLY COMMIT.

ASSOCIATED PR: [CUTE#18](https://github.com/OpenXiangShan/CUTE/pull/18)

## Summary

This PR connects CUTE performance events into XiangShan's native HPM infrastructure instead of keeping a separate CUTE-local PMU/CSR path.

The design goal is intentionally conservative:

- no new CSR registers
- no change to `cycle` / `instret` architectural behavior
- keep the existing backend HPM prefix stable
- append all CUTE events at the tail of the existing backend / mem event pools
- preserve the existing 6-bit perf event path

In other words, this change makes CUTE events software-visible through the CPU core's existing `mhpmevent` / `mhpmcounter` mechanism rather than through an independent CSR family.

This PR also depends on a preceding backend event-pool stabilization step that landed as:

- `fix(HPM): align backend event index to kunminghu-v2`

That earlier change is part of the story here and is not just incidental cleanup. Without it, the backend event pool would still contain matrix-related insertions interleaved into the original kunminghu-v2 ordering, and the newly added CUTE backend events would not have a stable software-visible numbering base.

## What Changes

### CUTE side

- Add lightweight perf probe bundles:
  - `TaskControllerPerfProbe`
  - `LocalMMUPerfProbe`
- Add a minimal sideband output bundle:
  - `CutePerfToCoreIO`
- Export CUTE perf candidates from:
  - `TaskController`
  - `LocalMMU`
- Assemble those raw candidates in `CUTETOP`
- Register the assembled perf sideband once at the `CUTETOP` output boundary before it crosses into the CPU core

### XSAI side

- Forward the CUTE perf sideband through:
  - `XSCuteTop`
  - `XSTile`
  - `XSCore`
- Extend `PerfCounterIO` with:
  - `perfEventsMatrixBackend`
  - `perfEventsMatrixMem`
- Preserve the original kunminghu-v2 backend `0..94` prefix by reusing the previously introduced base/ext split in:
  - `Rename`
  - `CtrlBlock`
  - `Backend`
- Append backend-side CUTE events to the backend event pool tail
- Append mem-side CUTE events to the MemBlock event pool tail

### What this PR does not do

- does not add a new AME-specific CSR map
- does not restore the abandoned standalone `PFEvent + HPerfMonitor + ame_* CSR` implementation
- does not modify `Frontend`
- does not add CUTE-originated cache-internal events into `CoupledL2/HuanCun`

## Event Placement

The new events are split by meaning rather than placed into a separate PMU domain.

### Backend prefix stabilization

Before appending CUTE backend events, the backend event pool is first stabilized so that:

- backend event IDs `0..94` remain identical to `kunminghu-v2`
- previously added matrix backend events are moved behind that stable prefix

This is implemented by splitting the backend event pool into a stable base segment and an extension segment:

- `Rename` exposes base/ext perf event views
- `CtrlBlock` keeps the original rename-free old prefix in its base view
- `Backend` rebuilds the final backend pool as:
  - stable old prefix first
  - pre-existing matrix backend extension next
  - newly added CUTE backend events last

As a result, this PR does not place the new CUTE backend events directly after `94`. They are appended after the already-existing backend extension region created by the earlier backend index-alignment fix.

The pre-existing backend extension region occupies IDs `95..104` and consists of:

| Event | ID |
| --- | ---: |
| `rename_stall_cycle_mx` | 95 |
| `me_freelist_1_4_valid` | 96 |
| `me_freelist_2_4_valid` | 97 |
| `me_freelist_3_4_valid` | 98 |
| `me_freelist_4_4_valid` | 99 |
| `IssueQueueMsetmtilexriwmfMrelease_full` | 100 |
| `issueQueue_enq_fire_cnt` | 101 |
| `IssueQueueMsetmtilexrmfwmf_full` | 102 |
| `IssueQueueMmaMarith_full` | 103 |
| `IssueQueueMls_full` | 104 |

### Backend-appended events

The following 9 events are appended after the existing backend event pool tail:

1. `amu_active_cycle`
2. `amu_retire`
3. `amu_comp_done`
4. `amu_release_done`
5. `amu_mte_active`
6. `amu_mma_nonfp`
7. `amu_mma_fp16`
8. `amu_mma_bf16`
9. `amu_mma_tf32`

For the current implementation, these appear after the already-stabilized backend prefix and extension region, so the final backend event IDs are:

| Event | ID |
| --- | ---: |
| `amu_active_cycle` | 105 |
| `amu_retire` | 106 |
| `amu_comp_done` | 107 |
| `amu_release_done` | 108 |
| `amu_mte_active` | 109 |
| `amu_mma_nonfp` | 110 |
| `amu_mma_fp16` | 111 |
| `amu_mma_bf16` | 112 |
| `amu_mma_tf32` | 113 |

### Mem-appended events

The following 12 events are appended after the existing MemBlock event pool tail:

1. `amu_load_a_done`
2. `amu_load_b_done`
3. `amu_load_c_done`
4. `amu_store_done`
5. `amu_aml_active`
6. `amu_bml_active`
7. `amu_cml_load_active`
8. `amu_cml_store_active`
9. `amu_mem_rd_req`
10. `amu_mem_wr_req`
11. `amu_mem_rd_32B_req`
12. `amu_mem_wr_32B_req`

For the current implementation, the final mem event IDs are:

| Event | ID |
| --- | ---: |
| `amu_load_a_done` | 145 |
| `amu_load_b_done` | 146 |
| `amu_load_c_done` | 147 |
| `amu_store_done` | 148 |
| `amu_aml_active` | 149 |
| `amu_bml_active` | 150 |
| `amu_cml_load_active` | 151 |
| `amu_cml_store_active` | 152 |
| `amu_mem_rd_req` | 153 |
| `amu_mem_wr_req` | 154 |
| `amu_mem_rd_32B_req` | 155 |
| `amu_mem_wr_32B_req` | 156 |

## Event Semantics

### Backend probes

- `amu_active_cycle`: exported from CUTE `ownedWork`, exposed to HPM under the more explicit public name `amu_active_cycle`
- `amu_retire`: CUTE task retire pulse
- `amu_comp_done`: compute completion pulse
- `amu_release_done`: release issue/completion pulse in the current scheduler model
- `amu_mte_active`: MTE busy cycle
- `amu_mma_nonfp/fp16/bf16/tf32`: compute completion classified by MMA data type

### Mem probes

- `amu_load_*_done` / `amu_store_done`: loader/store completion pulses
- `amu_*_active`: loader/store busy-cycle style probes
- `amu_mem_rd_req` / `amu_mem_wr_req`: LocalMMU outgoing read/write request fires
- `amu_mem_rd_32B_req` / `amu_mem_wr_32B_req`: outgoing traffic counted in `32B` units

The `32B` unit choice is deliberate. It preserves the existing 6-bit perf event width and avoids widening the global perf infrastructure just to carry byte-count values.

## Timing Note

The original sideband wiring from CUTE into the core was effectively combinational until the event reached the native HPM logic.

To reduce physical-design risk, the assembled CUTE perf sideband is now registered once at the `CUTETOP` output boundary before crossing into the CPU core. This keeps the fix narrow:

- the event definitions remain unchanged
- the native HPM path remains unchanged
- only the cross-module perf sideband gains one cycle of latency

This is a timing-oriented implementation detail, not a software-visible semantic change.

## Implementation Details

### `XSAI/CUTE`

- `Bundles.scala`
  - add `CutePerfEventCounts`
  - add `TaskControllerPerfProbe`
  - add `LocalMMUPerfProbe`
  - add `CutePerfToCoreIO`
- `TaskController.scala`
  - export done/retire/active probe signals
- `LocalMMU.scala`
  - export request-fire and `32B`-unit traffic probes
- `CUTETOP.scala`
  - expose `perf`
  - assemble backend/mem raw candidate events
  - add one output-side register stage for the perf sideband

### `XSAI`

- `cutewrapper/XSCuteTop.scala`
  - forward the CUTE perf sideband
- `xiangshan/XSTile.scala`
  - connect CUTE perf sideband into the core
  - provide zero default when CUTE is absent
- `xiangshan/XSCore.scala`
  - consume the sideband and map it into backend/mem perf inputs
- `xiangshan/backend/fu/CSR.scala`
  - extend `PerfCounterIO` with backend/mem CUTE perf inputs
- `xiangshan/backend/rename/Rename.scala`
  - keep the old rename/free-list prefix intact
  - move pre-existing matrix rename events into the backend extension region
- `xiangshan/backend/CtrlBlock.scala`
  - expose backend base/ext event views so the old ctrlblock prefix remains stable
- `xiangshan/backend/Backend.scala`
  - reuse the stabilized backend base/ext ordering introduced by `fix(HPM): align backend event index to kunminghu-v2`
  - append backend CUTE events at the backend pool tail
- `xiangshan/mem/MemBlock.scala`
  - append mem CUTE events at the mem pool tail

## Validation

- Scala/elaboration-level compile check passed:
  - `mill -i xiangshan.compile`
  - `make xsai`
- AM test case updated and used to validate native HPM programming through:
  - `mhpmevent11..18` for backend-side CUTE events
  - `mhpmevent19..26` for mem-side CUTE events
- The test confirmed:
  - backend CUTE events can be selected and counted through native HPM
  - mem CUTE request / traffic events can be selected and counted through native HPM
  - per-case counter reset by writing `0` to `mhpmcounter*` behaves as expected

## Review Focus

- correctness of the backend/mem event split
- stability of existing backend and mem event prefixes
- correctness of the final event ordering and IDs
- correctness of `32B`-unit traffic accounting
- safety of the single register stage added at the `CUTETOP` perf boundary
- nested-submodule integration between `XSAI/CUTE` and `XSAI`
