### PR TITLE
ci: update GitHub Actions for Node.js 24

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -18,8 +18,8 @@ jobs:
     outputs:
       core: ${{ steps.filter.outputs.core }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: actions/checkout@v7
+    - uses: dorny/paths-filter@v4
       id: filter
       with:
         predicate-quantifier: 'every'
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 900
     name: Generate XSAI Verilog
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: true
@@ -94,7 +94,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - XSAI Basics
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: true
@@ -192,7 +192,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build docker image
         run: make image
@@ -208,7 +208,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - XSAI General-Purpose Performance
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: true
@@ -319,7 +319,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - XSAI MC
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: true
@@ -359,7 +359,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - XS without Matrix
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: true
@@ -406,7 +406,7 @@ jobs:
     timeout-minutes: 900
     name: Check Format
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
       - uses: actions/setup-java@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
     # Build + 8 checkpoints * 1-hour timeout
     name: Nightly Regression(master) - Checkpoints
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: true
@@ -112,7 +112,7 @@ jobs:
       # Build + 8 checkpoints * 1-hour timeout
       name: Nightly Regression(kunminghu-v3) - Checkpoints
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v7
           with:
             ref: kunminghu-v3
             fetch-depth: 0

--- a/.github/workflows/perf-template.yml
+++ b/.github/workflows/perf-template.yml
@@ -65,7 +65,7 @@ jobs:
           fi
 
       - name: Checkout code at specific commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.set_test.outputs.commit_sha }}
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Initialize submodules 
         run: make init-force
@@ -48,7 +48,7 @@ jobs:
   build-xspdb:
     runs-on: [self-hosted, xspdb]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: true
@@ -86,4 +86,3 @@ jobs:
         with:
           name: ${{ env.FILE_NAME }}
           path: build/xspdb/${{ env.FILE_NAME }}
-


### PR DESCRIPTION
- bump actions/checkout from v4 to v7
- bump dorny/paths-filter from v3 to v4