### PR TITLE
feat(cache): integrate ZhuJiang LLC

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -79,6 +79,10 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
       - name: build MinimalMatrixConfig Release emu
         run: |
+          sed -i \
+            -e 's/--output-split 30000/--output-split 10000/' \
+            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 10000/' \
+            $GITHUB_WORKSPACE/difftest/verilator.mk
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --threads 8 --config MinimalMatrixConfig --release --trace-fst
       - name: run MinimalMatrixConfig - Linux
@@ -116,6 +120,10 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
       - name: Build EMU
         run: |
+          sed -i \
+            -e 's/--output-split 30000/--output-split 10000/' \
+            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 10000/' \
+            $GITHUB_WORKSPACE/difftest/verilator.mk
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build --threads 8 \
             --config DefaultMatrixConfig --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata --trace-fst
       - name: Basic Test - cputest
@@ -230,6 +238,10 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
       - name: Build EMU
         run: |
+          sed -i \
+            -e 's/--output-split 30000/--output-split 10000/' \
+            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 10000/' \
+            $GITHUB_WORKSPACE/difftest/verilator.mk
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 --threads 8 \
             --config DefaultMatrixConfig \
@@ -340,6 +352,10 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
       - name: Build MC EMU
         run: |
+          sed -i \
+            -e 's/--output-split 30000/--output-split 10000/' \
+            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 10000/' \
+            $GITHUB_WORKSPACE/difftest/verilator.mk
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --num-cores 2 --emu-optimize "" --config DefaultMatrixConfig \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 --threads 8 \
@@ -381,6 +397,10 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
       - name: Build EMU
         run: |
+          sed -i \
+            -e 's/--output-split 30000/--output-split 10000/' \
+            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 10000/' \
+            $GITHUB_WORKSPACE/difftest/verilator.mk
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --config DefaultConfig \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 --threads 8 \

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -80,8 +80,8 @@ jobs:
       - name: build MinimalMatrixConfig Release emu
         run: |
           sed -i \
-            -e 's/--output-split 30000/--output-split 10000/' \
-            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 10000/' \
+            -e 's/--output-split 30000/--output-split 5000/' \
+            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 5000/' \
             $GITHUB_WORKSPACE/difftest/verilator.mk
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --threads 8 --config MinimalMatrixConfig --release --trace-fst
@@ -121,8 +121,8 @@ jobs:
       - name: Build EMU
         run: |
           sed -i \
-            -e 's/--output-split 30000/--output-split 10000/' \
-            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 10000/' \
+            -e 's/--output-split 30000/--output-split 5000/' \
+            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 5000/' \
             $GITHUB_WORKSPACE/difftest/verilator.mk
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build --threads 8 \
             --config DefaultMatrixConfig --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata --trace-fst
@@ -239,8 +239,8 @@ jobs:
       - name: Build EMU
         run: |
           sed -i \
-            -e 's/--output-split 30000/--output-split 10000/' \
-            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 10000/' \
+            -e 's/--output-split 30000/--output-split 5000/' \
+            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 5000/' \
             $GITHUB_WORKSPACE/difftest/verilator.mk
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 --threads 8 \
@@ -353,8 +353,8 @@ jobs:
       - name: Build MC EMU
         run: |
           sed -i \
-            -e 's/--output-split 30000/--output-split 10000/' \
-            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 10000/' \
+            -e 's/--output-split 30000/--output-split 5000/' \
+            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 5000/' \
             $GITHUB_WORKSPACE/difftest/verilator.mk
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --num-cores 2 --emu-optimize "" --config DefaultMatrixConfig \
@@ -398,8 +398,8 @@ jobs:
       - name: Build EMU
         run: |
           sed -i \
-            -e 's/--output-split 30000/--output-split 10000/' \
-            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 10000/' \
+            -e 's/--output-split 30000/--output-split 5000/' \
+            -e 's/--output-split-cfuncs 30000/--output-split-cfuncs 5000/' \
             $GITHUB_WORKSPACE/difftest/verilator.mk
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --config DefaultConfig \

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -116,7 +116,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
       - name: Build EMU
         run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build --threads 16 \
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build --threads 8 \
             --config DefaultMatrixConfig --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata --trace-fst
       - name: Basic Test - cputest
         run: |
@@ -231,7 +231,7 @@ jobs:
       - name: Build EMU
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
-            --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 --threads 16 \
+            --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 --threads 8 \
             --config DefaultMatrixConfig \
             --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata --trace-fst
       - name: SPEC06 Test - hmmer-Vector
@@ -342,7 +342,7 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --num-cores 2 --emu-optimize "" --config DefaultMatrixConfig \
-            --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 --threads 16 \
+            --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 --threads 8 \
             --pgo /nfs/home/share/ci-workloads/linux-hello-smp-new/bbl.bin --llvm-profdata llvm-profdata --trace-fst
       - name: MC Test
         run: |
@@ -383,7 +383,7 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --config DefaultConfig \
-            --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 --threads 16 \
+            --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 --threads 8 \
             --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata --trace-fst
       - name: Simple Test - CoreMark
         id: coremark

--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,21 @@ MEM_GEN_SEP = ./scripts/gen_sep_mem.sh
 CONFIG ?= DefaultConfig
 NUM_CORES ?= 1
 ISSUE ?= E.b
+LLC ?= ZhuJiang
 CHISEL_TARGET ?= systemverilog
 
 SUPPORT_CHI_ISSUE = B C E.b
 ifeq ($(findstring $(ISSUE), $(SUPPORT_CHI_ISSUE)),)
 $(error "Unsupported CHI issue: $(ISSUE)")
+endif
+SUPPORT_LLC = OpenLLC ZhuJiang
+ifeq ($(filter $(LLC), $(SUPPORT_LLC)),)
+$(error "Unknown LLC: $(LLC)")
+endif
+ifeq ($(LLC),ZhuJiang)
+ifneq ($(ISSUE),E.b)
+$(error "LLC=ZhuJiang only supports ISSUE=E.b or newer")
+endif
 endif
 
 ifneq ($(shell echo "$(MAKECMDGOALS)" | grep ' '),)
@@ -126,6 +136,9 @@ endif
 ifneq ($(CHI_ADDR_WIDTH),)
 COMMON_EXTRA_ARGS += --chi-addr-width $(CHI_ADDR_WIDTH)
 endif
+
+# LLC backend selection
+COMMON_EXTRA_ARGS += --llc $(LLC)
 
 # L2 cache size in KB
 ifneq ($(L2_CACHE_SIZE),)
@@ -315,7 +328,7 @@ GIT_FORCE_FLAG := $(if $(GIT_FORCE_INIT),--force)
 init:
 	git submodule update --init $(GIT_FORCE_FLAG)
 	cd rocket-chip && git submodule update --init $(GIT_FORCE_FLAG) cde hardfloat
-	cd XSAICache && git submodule update --init $(GIT_FORCE_FLAG) OpenNCB
+	cd XSAICache && git submodule update --init $(GIT_FORCE_FLAG) OpenNCB ZhuJiang
 	cd CUTE && git submodule update --init $(GIT_FORCE_FLAG) cute-fpe
 
 # Initialize necessary submodules (force)

--- a/build.sc
+++ b/build.sc
@@ -151,6 +151,29 @@ object openNCB extends SbtModule with HasChisel {
 
 }
 
+object zhujiangCompat extends SbtModule with HasChisel {
+
+  override def millSourcePath = pwd / "XSAICache" / "ZhuJiang"
+
+  override def moduleDeps = super.moduleDeps ++ Seq(
+    rocketchip,
+    utility
+  )
+
+  override def sources = T.sources {
+    val sourceRoots = Seq(
+      millSourcePath / "src" / "main" / "scala",
+      millSourcePath / "xs-utils" / "src" / "main" / "scala"
+    )
+    sourceRoots
+      .flatMap(os.walk(_))
+      .filter(path => os.isFile(path) && path.ext == "scala")
+      .filterNot(_.last == "XsStage.scala")
+      .map(PathRef(_))
+  }
+
+}
+
 object XSAICache extends $file.XSAICache.common.XSCacheModule with HasChisel {
 
   override def millSourcePath = pwd / "XSAICache"
@@ -160,6 +183,14 @@ object XSAICache extends $file.XSAICache.common.XSCacheModule with HasChisel {
   def rocketModule: ScalaModule = rocketchip
 
   def utilityModule: ScalaModule = utility
+
+  override def moduleDeps = super.moduleDeps ++ Seq(zhujiangCompat)
+
+  override def sources = T.sources {
+    super.sources() ++ Seq(
+      PathRef(millSourcePath / "src" / "test" / "scala" / "ZhuJiangBridge.scala")
+    )
+  }
 
 }
 
@@ -269,6 +300,8 @@ trait XiangShanModule extends ScalaModule {
 
   def cuteModule: ScalaModule
 
+  def zhujiangCompatModule: ScalaModule
+
   override def moduleDeps = super.moduleDeps ++ Seq(
     rocketModule,
     difftestModule,
@@ -279,7 +312,8 @@ trait XiangShanModule extends ScalaModule {
     chiselAIAModule,
     macrosModule,
     chiselIOPMPModule,
-    cuteModule
+    cuteModule,
+    zhujiangCompatModule
   )
 
   val resourcesPATH = pwd.toString() + "/src/main/resources"
@@ -311,6 +345,8 @@ object xiangshan extends XiangShanModule with HasChisel with ScalafmtModule {
   def chiselIOPMPModule = chiselIOPMP
 
   def cuteModule = CUTE
+
+  def zhujiangCompatModule = zhujiangCompat
 
   // properties may be changed by user. Use `Task.Input` here.
   def forkArgsTask = Task.Input {

--- a/src/main/resources/config/Default.yml
+++ b/src/main/resources/config/Default.yml
@@ -17,9 +17,13 @@ PMAConfigs:
 
 EnableCHIAsyncBridge: true
 
+LLC: ZhuJiang
+
 L2CacheConfig: { size: 1 MB, ways: 8, inclusive: true, banks: 4, tp: true, enableFlush: false }
 
 OpenLLCConfig: { size: 16 MB, ways: 16, banks: 4 }
+
+ZhuJiangConfig: { size: 16 MB, ways: 16 }
 
 HartIDBits: 6
 

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -34,10 +34,11 @@ import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
 import freechips.rocketchip.regmapper.{RegField, RegFieldDesc, RegFieldGroup}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util.{AsyncQueueParams}
-import top.BusPerfMonitor
+import top.{BusPerfMonitor, LLCType}
 import xiangshan.backend.fu.{MemoryRange, PMAConfigEntry, PMAConst}
 import xiangshan.{DebugOptionsKey, PMParameKey, XSTileKey}
 import device.SYSCNTConsts.timeWidth
+import zhujiang.ZJParameters
 
 case object SoCParamsKey extends Field[SoCParameters]
 case object CVMParamsKey extends Field[CVMParameters]
@@ -84,7 +85,9 @@ case class SoCParameters
   UARTLiteForDTS: Boolean = true, // should be false in SimMMIO
   extIntrs: Int = 64,
   L3NBanks: Int = 4,
+  LLC: LLCType.Value = LLCType.OpenLLC,
   OpenLLCParamsOpt: Option[OpenLLCParam] = None,
+  ZhuJiangParams: ZJParameters = ZJParameters(),
   XSTopPrefix: Option[String] = None,
   NodeIDWidthList: Map[String, Int] = Map(
     "B" -> 7,
@@ -147,6 +150,26 @@ trait HasSoCParameter {
   val tiles = p(XSTileKey)
   val enableCHI = true
   val issue = p(CHIIssue)
+  val isOpenLLC = soc.LLC == LLCType.OpenLLC
+  val isZhuJiang = soc.LLC == LLCType.ZhuJiang
+
+  if (isZhuJiang) {
+    require(issue == xscache.chi.Issue.Eb, "LLC=ZhuJiang only supports CHI issue E.b or newer")
+    require(
+      soc.EnableCHIAsyncBridge.isEmpty,
+      "LLC=ZhuJiang does not support EnableCHIAsyncBridge"
+    )
+    require(!soc.EnablePowerDown, "LLC=ZhuJiang does not support power-down flows")
+    require(!soc.WFIClockGate, "LLC=ZhuJiang does not support WFI clock gating")
+    require(
+      !tiles.exists(_.L2CacheParamsOpt.exists(_.enableL2Flush)),
+      "LLC=ZhuJiang does not support flushL2"
+    )
+    require(
+      !tiles.exists(_.L2CacheParamsOpt.exists(l2 => l2.dataCheck.nonEmpty || l2.enablePoison)),
+      "LLC=ZhuJiang requires CoupledL2 DataCheck and Poison disabled"
+    )
+  }
 
   val NumCores = tiles.size
   val EnableILA = soc.EnableILA
@@ -180,8 +203,7 @@ trait HasSoCParameter {
   val SeperateBus = soc.SeperateBus
   val SeperateBusRanges = soc.SeperateBusRanges
 
-  val EnableCHIAsyncBridge = if (enableCHI && soc.EnableCHIAsyncBridge.isDefined)
-    soc.EnableCHIAsyncBridge else None
+  val EnableCHIAsyncBridge = soc.EnableCHIAsyncBridge
   val EnableClintAsyncBridge = soc.EnableClintAsyncBridge
   val SeperateBusAsyncBridge = soc.SeperateBusAsyncBridge
 

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -190,14 +190,16 @@ object ArgParser {
           nextOption(config.alter((site, here, up) => {
             case SoCParamsKey =>
               val socParam = up(SoCParamsKey)
+              val sizeInBytes = value.toInt * 1024
               val banks = socParam.OpenLLCParamsOpt.map(_.banks).getOrElse(socParam.L3NBanks)
               val openLLCWays = socParam.OpenLLCParamsOpt.map(_.ways)
-              val openLLCSets = openLLCWays.map(value.toInt * 1024 / banks / _ / 64)
+              val openLLCSets = openLLCWays.map(sizeInBytes / banks / _ / 64)
               val openLLCParam = socParam.OpenLLCParamsOpt.map(_.copy(
                 sets = openLLCSets.get
               ))
               socParam.copy(
-                OpenLLCParamsOpt = openLLCParam
+                OpenLLCParamsOpt = openLLCParam,
+                ZhuJiangParams = socParam.ZhuJiangParams.copy(cacheSizeInB = sizeInBytes)
               )
           }), tail)
         case "--sim-mem-size" :: value :: tail =>

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -37,6 +37,7 @@ object ArgParser {
       |--xs-help                  print this help message
       |--version                  print version info
       |--config <ConfigClassName>
+      |--llc <OpenLLC|ZhuJiang>
       |--num-cores <Int>
       |--hartidbits <Int>
       |--with-dramsim3
@@ -82,6 +83,8 @@ object ArgParser {
           nextOption(config.alter((site, here, up) => {
             case xscache.chi.CHIIssue => issueString
           }), tail)
+        case "--llc" :: llcString :: tail =>
+          nextOption(config.alter(LLCConfig(llcString)), tail)
         case "--num-cores" :: value :: tail =>
           nextOption(config.alter((site, here, up) => {
             case XSTileKey => (0 until value.toInt) map { i =>

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -37,6 +37,20 @@ import xscache.coupledL2._
 import xscache.coupledL2.prefetch._
 import xscache.common.DirtyField
 import cute.{CuteParamsKey, CuteParams, CuteDebugParams, Cutev3extParams, MatrixIsaParams}
+import zhujiang.ZJParameters
+
+object LLCType extends Enumeration {
+  val OpenLLC, ZhuJiang = Value
+}
+
+private[top] object CacheSizeParser {
+  def toBytes(size: String): Int = size.toUpperCase.replace(" ", "") match {
+    case s"${k}KB" => k.trim.toInt * 1024
+    case s"${m}MB" => (m.trim.toDouble * 1024 * 1024).toInt
+    case s"${g}GB" => (g.trim.toDouble * 1024 * 1024 * 1024).toInt
+    case bytes => bytes.trim.toInt
+  }
+}
 
 class BaseConfig(n: Int) extends Config((site, here, up) => {
   case XLen => 64
@@ -381,11 +395,8 @@ case class L2CacheConfig
 
 case class OpenLLCConfig(size: String, ways: Int = 8, banks: Int = 1) extends Config((site, here, up) => {
   case SoCParamsKey =>
-    val nKB = size.toUpperCase() match {
-      case s"${k}KB" => k.trim().toInt
-      case s"${m}MB" => (m.trim().toDouble * 1024).toInt
-    }
-    val sets = nKB * 1024 / banks / ways / 64
+    val sizeInBytes = CacheSizeParser.toBytes(size)
+    val sets = sizeInBytes / banks / ways / 64
     val tiles = site(XSTileKey)
     val clientDirBytes = tiles.map{ t =>
       t.L2NBanks * t.L2CacheParamsOpt.map(_.toCacheParams.capacity).getOrElse(0)
@@ -406,6 +417,32 @@ case class OpenLLCConfig(size: String, ways: Int = 8, banks: Int = 1) extends Co
         elaboratedTopDown = !site(DebugOptionsKey).FPGAPlatform
       ))
     )
+})
+
+case class LLCConfig(llc: String) extends Config((site, here, up) => {
+  case SoCParamsKey =>
+    val llcType = LLCType.withName(llc)
+    val soc = up(SoCParamsKey).copy(LLC = llcType)
+    if (llcType == LLCType.ZhuJiang) {
+      soc.copy(EnableCHIAsyncBridge = None)
+    } else {
+      soc
+    }
+  case XSTileKey if LLCType.withName(llc) == LLCType.ZhuJiang =>
+    up(XSTileKey).map { tile =>
+      tile.copy(L2CacheParamsOpt = tile.L2CacheParamsOpt.map(_.copy(
+        dataCheck = None,
+        enablePoison = false
+      )))
+    }
+})
+
+case class ZhuJiangConfig(size: String, ways: Int = 16) extends Config((site, here, up) => {
+  case SoCParamsKey =>
+    up(SoCParamsKey).copy(ZhuJiangParams = ZJParameters(
+      cacheSizeInB = CacheSizeParser.toBytes(size),
+      cacheWays = ways
+    ))
 })
 
 class WithL3DebugConfig extends Config(

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -432,14 +432,17 @@ case class LLCConfig(llc: String) extends Config((site, here, up) => {
     up(XSTileKey).map { tile =>
       tile.copy(L2CacheParamsOpt = tile.L2CacheParamsOpt.map(_.copy(
         dataCheck = None,
-        enablePoison = false
+        enablePoison = false,
+        bufferableNC = false,
+        endpointOrderNC = true
       )))
     }
 })
 
 case class ZhuJiangConfig(size: String, ways: Int = 16) extends Config((site, here, up) => {
   case SoCParamsKey =>
-    up(SoCParamsKey).copy(ZhuJiangParams = ZJParameters(
+    val soc = up(SoCParamsKey)
+    soc.copy(ZhuJiangParams = soc.ZhuJiangParams.copy(
       cacheSizeInB = CacheSizeParser.toBytes(size),
       cacheWays = ways
     ))
@@ -518,6 +521,7 @@ class FuzzConfig(dummy: Int = 0) extends Config(
 
 class DefaultConfig(n: Int = 1) extends Config(
   OpenLLCConfig("16MB", banks = 4, ways = 16)
+    ++ ZhuJiangConfig("16MB", ways = 16)
     ++ L2CacheConfig("1MB", banks = 4)
     ++ WithNKBL1D(64, ways = 4)
     ++ new BaseConfig(n)

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -28,6 +28,11 @@ import utility.sram.SramBroadcastBundle
 import xscache.chi.CHILogger
 import xscache.openLLC.{OpenLLC, OpenLLCParamKey, OpenNCB}
 import xscache.openLLC.TargetBinder._
+import xs.utils.debug.{HardwareAssertionKey, HwaParams}
+import xs.utils.perf.{DebugOptions => ZJDebugOptions, DebugOptionsKey => ZJDebugOptionsKey}
+import xs.utils.perf.{LogUtilsOptions => ZJLogUtilsOptions, LogUtilsOptionsKey => ZJLogUtilsOptionsKey}
+import xs.utils.perf.{PerfCounterOptions => ZJPerfCounterOptions, PerfCounterOptionsKey => ZJPerfCounterOptionsKey, XSPerfLevel => ZJXSPerfLevel}
+import zhujiang.{HasCHIToZhuJiangBridge, HasZhuJiangAXI4Bridge, Zhujiang, ZJParametersKey}
 import cc.xiangshan.openncb._
 import system._
 import device._
@@ -83,10 +88,11 @@ trait HasDTSImp[+L <: BaseXSSoc] { this: LazyRawModuleImp =>
 }
 
 class XSTop()(implicit p: Parameters) extends BaseXSSoc()
+  with HasCHIToZhuJiangBridge
+  with HasZhuJiangAXI4Bridge
 {
-  val nocMisc = if (enableCHI) Some(LazyModule(new MemMisc())) else None
-  val socMisc = if (!enableCHI) Some(LazyModule(new SoCMisc())) else None
-  val misc: MemMisc = if (enableCHI) nocMisc.get else socMisc.get
+  val nocMisc = Some(LazyModule(new MemMisc()))
+  val misc: MemMisc = nocMisc.get
 
   override lazy val tlManagers = List(
     misc.l3_xbar.map(_.asInstanceOf[TLNexusNode]),
@@ -102,7 +108,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     })))
   )
 
-  val chi_llcBridge_opt = Option.when(enableCHI)(
+  val chi_llcBridge_opt = Option.when(isOpenLLC)(
     LazyModule(new OpenNCB()(p.alter((site, here, up) => {
       case NCBParametersKey => new NCBParameters(
         outstandingDepth    = 64,
@@ -116,7 +122,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     })))
   )
 
-  val chi_mmioBridge_opt = Seq.fill(NumCores)(Option.when(enableCHI)(
+  val chi_mmioBridge_opt = Seq.fill(NumCores)(Option.when(isOpenLLC)(
     LazyModule(new OpenNCB()(p.alter((site, here, up) => {
       case NCBParametersKey => new NCBParameters(
         outstandingDepth            = 32,
@@ -143,10 +149,6 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     core_with_l2(i).debug_int_node := misc.debugModule.debug.dmOuter.dmOuter.intnode
     core_with_l2(i).nmi_int_node := nmiIntNode
     misc.plic.intnode := IntBuffer() := core_with_l2(i).beu_int_source
-    if (!enableCHI) {
-      misc.peripheral_ports.get(i) := core_with_l2(i).tl_uncache
-    }
-    core_with_l2(i).memory_port.foreach(port => (misc.core_to_l3_ports.get)(i) :=* port)
     misc.SepTLXbarOpt.foreach { SepTLXbarOpt =>
       // SeperateBus can only be connected to DebugModule now in non-XSNoCTop environment
       println(s"SeparateDM: ${SeperateDM}")
@@ -178,6 +180,42 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     }
   }
 
+  private val zhujiangNocConfig = Option.when(isZhuJiang)(
+    ZhuJiangNoCTopology(NumCores, soc.ZhuJiangParams, L3OuterBusWidth)
+  )
+  private val zhujiangCfgNodes = zhujiangNocConfig
+    .map(_.island.filter(_.nodeType == xijiang.NodeType.HI))
+    .getOrElse(Seq.empty)
+
+  val zhujiangMemMaster = Option.when(isZhuJiang)(AXI4MasterNode(Seq(AXI4MasterPortParameters(
+    masters = Seq(AXI4MasterParameters(
+      name = "zhujiang-mem",
+      id = IdRange(0, 8),
+      aligned = true,
+      maxFlight = Some(1)
+    ))
+  ))))
+
+  zhujiangMemMaster.foreach { master =>
+    misc.soc_xbar.get := master
+  }
+
+  val zhujiangCfgMasters = zhujiangCfgNodes.zipWithIndex.map { case (node, i) =>
+    val outstanding = node.axiDevParams.map(_.outstanding).getOrElse(8)
+    AXI4MasterNode(Seq(AXI4MasterPortParameters(
+      masters = Seq(AXI4MasterParameters(
+        name = s"zhujiang-cfg-$i",
+        id = IdRange(0, outstanding),
+        aligned = true,
+        maxFlight = Some(1)
+      ))
+    )))
+  }
+
+  zhujiangCfgMasters.foreach { master =>
+    misc.soc_xbar.get := AXI4Buffer() := master
+  }
+
   class XSTopImp(wrapper: XSTop) extends LazyRawModuleImp(wrapper)
     with HasDTSImp[XSTop]
   {
@@ -186,16 +224,8 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
       annotate(this)(Seq(NestedPrefixModulesAnnotation(mod, prefix, true)))
     }
 
-    val dma = socMisc.map(m => IO(Flipped(new VerilogAXI4Record(m.dma.elts.head.params))))
     val peripheral = IO(new VerilogAXI4Record(misc.peripheral.elts.head.params))
     val memory = IO(new VerilogAXI4Record(misc.memory.elts.head.params))
-
-    socMisc match {
-      case Some(m) =>
-        m.dma.elements.head._2 <> dma.get.viewAs[AXI4Bundle]
-        dontTouch(dma.get)
-      case None =>
-    }
 
     memory.viewAs[AXI4Bundle] <> misc.memory.elements.head._2
     peripheral.viewAs[AXI4Bundle] <> misc.peripheral.elements.head._2
@@ -241,7 +271,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
 
     val reset_sync = withClockAndReset(io.clock, io.reset) { ResetGen() }
     val jtag_reset_sync = withClockAndReset(io.systemjtag.jtag.TCK, io.systemjtag.reset) { ResetGen() }
-    val chi_openllc_opt = Option.when(enableCHI)(
+    val chi_openllc_opt = Option.when(isOpenLLC)(
       withClockAndReset(io.clock, io.reset) {
         Module(new OpenLLC()(p.alter((site, here, up) => {
           case OpenLLCParamKey => soc.OpenLLCParamsOpt.get.copy(
@@ -249,6 +279,39 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
             FPGAPlatform = debugOpts.FPGAPlatform
           )
         })))
+      }
+    )
+    val zhujiangParams = p.alterPartial {
+      case ZJParametersKey => ZhuJiangNoCTopology(NumCores, soc.ZhuJiangParams, L3OuterBusWidth)
+      case HardwareAssertionKey => HwaParams(enable = false)
+      case ZJLogUtilsOptionsKey => ZJLogUtilsOptions(
+        enableDebug = false,
+        enablePerf = debugOpts.EnablePerfDebug,
+        fpgaPlatform = debugOpts.FPGAPlatform
+      )
+      case ZJPerfCounterOptionsKey => ZJPerfCounterOptions(
+        enablePerfPrint = debugOpts.EnablePerfDebug && !debugOpts.FPGAPlatform,
+        enablePerfDB = debugOpts.EnableRollingDB && !debugOpts.FPGAPlatform,
+        perfLevel = ZJXSPerfLevel.withName(debugOpts.PerfLevel),
+        perfDBHartID = 0
+      )
+      case ZJDebugOptionsKey => ZJDebugOptions(
+        FPGAPlatform = debugOpts.FPGAPlatform,
+        EnableDifftest = false,
+        AlwaysBasicDiff = false,
+        EnableDebug = false,
+        EnablePerfDebug = debugOpts.EnablePerfDebug,
+        UseDRAMSim = false,
+        EnableTopDown = false,
+        EnableChiselDB = false,
+        AlwaysBasicDB = false,
+        EnableRollingDB = debugOpts.EnableRollingDB,
+        EnableHWMoniter = false
+      )
+    }
+    val zhujiang_opt = Option.when(isZhuJiang)(
+      withClockAndReset(io.clock, io.reset) {
+        Module(new Zhujiang()(zhujiangParams))
       }
     )
 
@@ -307,11 +370,10 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     }
 
     withClockAndReset(io.clock, io.reset) {
-      Option.when(enableCHI)(true.B).foreach { _ =>
+      Option.when(isOpenLLC)(true.B).foreach { _ =>
         for ((core, i) <- core_with_l2.zipWithIndex) {
           val mmioLogger = CHILogger(s"L2[${i}]_MMIO", true)
           val llcLogger = CHILogger(s"L2[${i}]_LLC", true)
-          dontTouch(core.module.io.chi.get)
           bind(
             route(
               core.module.io.chi.get, Map((AddressSet(0x0L, 0x00007fffffffL), NumCores + i)) ++ AddressSet(0x0L,
@@ -338,12 +400,46 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
       }
     }
 
+    zhujiang_opt.foreach { zj =>
+      withClockAndReset(io.clock, io.reset) {
+        val zjp = zhujiangNocConfig.get
+        val ccNodes = zjp.island.filter(_.nodeType == xijiang.NodeType.CC)
+        require(ccNodes.size >= NumCores, s"ZhuJiang exposes ${ccNodes.size} CC nodes, but $NumCores cores are requested")
+        require(zj.ccnIO.size >= NumCores, s"ZhuJiang exposes ${zj.ccnIO.size} CCN IOs, but $NumCores cores are requested")
+        require(zj.ddrIO.nonEmpty, "XSAI + ZhuJiang expects at least one DDR AXI port")
+        require(
+          zj.cfgIO.size == zhujiangCfgMasters.size,
+          s"ZhuJiang exposes ${zj.cfgIO.size} cfg AXI ports, but ${zhujiangCfgMasters.size} cfg master nodes were built"
+        )
+
+        for ((core, i) <- core_with_l2.zipWithIndex) {
+          connectCHIToZhuJiang(core.module.io.decoupledCHI.get, zj.ccnIO(i), ccNodes(i), zhujiangParams)
+        }
+
+        zj.io.ci := 0.U
+        zj.io.dft := DontCare
+        zj.io.ramctl := DontCare
+        val (zjMemAxi, _) = zhujiangMemMaster.get.out.head
+        connectZJToAXI4(zj.ddrIO.head, zjMemAxi)
+        zj.ddrIO.drop(1).foreach { axi => axi := DontCare }
+        zj.cfgIO.zip(zhujiangCfgMasters).foreach { case (cfg, master) =>
+          val (cfgAxi, _) = master.out.head
+          connectZJToAXI4(cfg, cfgAxi)
+        }
+        zj.dmaIO.foreach { axi => axi := DontCare }
+        zj.hwaIO.foreach { axi => axi := DontCare }
+
+        core_with_l2.foreach(_.module.io.debugTopDown.l3MissMatch := false.B)
+        core_with_l2.foreach(_.module.io.l3Miss := false.B)
+      }
+    }
+
     // tie off core soft reset
     for(node <- core_rst_nodes){
       node.out.head._1 := false.B.asAsyncReset
     }
 
-    chi_openllc_opt match {
+    if (isOpenLLC) chi_openllc_opt match {
       case Some(l3) =>
         l3.io.debugTopDown.robHeadPaddr := core_with_l2.map(_.module.io.debugTopDown.robHeadPaddr)
         core_with_l2.zip(l3.io.debugTopDown.addrMatch).foreach { case (tile, l3Match) =>

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -267,19 +267,19 @@ trait HasXSTileImp[+L <: HasXSTile] { this: BaseXSSocImp with HasAsyncClockImp =
 trait HasXSTileCHIImp[+L <: HasXSTile] extends HasXSTileImp[L] {
   this: BaseXSSocImp with HasAsyncClockImp =>
 
-  val io_chi = IO(new PortIO)
+  require(socParams.isOpenLLC, "XSNoCTop currently supports only LLC=OpenLLC")
 
-  require(socParams.enableCHI)
+  val io_chi = IO(new PortIO)
 
   socParams.EnableCHIAsyncBridge match {
     case Some(param) =>
       withClockAndReset(noc_clock.get, noc_reset_sync.get) {
         val time_sink = Module(new CHIAsyncBridgeSink(param))
-        time_sink.io.async <> core_with_l2.module.io.chi
+        time_sink.io.async <> core_with_l2.module.io.chi.get
         io_chi <> time_sink.io.deq
       }
     case None =>
-      io_chi <> core_with_l2.module.io.chi
+      io_chi <> core_with_l2.module.io.chi.get
   }
 }
 

--- a/src/main/scala/top/YamlParser.scala
+++ b/src/main/scala/top/YamlParser.scala
@@ -37,8 +37,10 @@ case class YamlConfig(
   PmemRanges: Option[List[MemoryRange]],
   PMAConfigs: Option[List[PMAConfigEntry]],
   EnableCHIAsyncBridge: Option[Boolean],
+  LLC: Option[String],
   L2CacheConfig: Option[L2CacheConfig],
   OpenLLCConfig: Option[OpenLLCConfig],
+  ZhuJiangConfig: Option[ZhuJiangConfig],
   HartIDBits: Option[Int],
   HartIDDmodeWidth: Option[Int],
   DebugAttachProtocals: Option[List[String]],
@@ -107,6 +109,10 @@ object YamlParser {
       newConfig = newConfig.alter(updatedL2)
     }
     yamlConfig.OpenLLCConfig.foreach(llc => newConfig = newConfig.alter(llc))
+    yamlConfig.ZhuJiangConfig.foreach(zj => newConfig = newConfig.alter(zj))
+    yamlConfig.LLC.foreach { llc =>
+      newConfig = newConfig.alter(LLCConfig(llc))
+    }
     yamlConfig.DebugAttachProtocals.foreach { protocols =>
       newConfig = newConfig.alter((site, here, up) => {
         case ExportDebug => DebugAttachParams(protocols = protocols.map {

--- a/src/main/scala/top/ZhuJiangNoCTopology.scala
+++ b/src/main/scala/top/ZhuJiangNoCTopology.scala
@@ -1,0 +1,64 @@
+/***************************************************************************************
+* Copyright (c) 2026 Beijing Institute of Open Source Chip (BOSC)
+*
+* XiangShan is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+package top
+
+import xijiang.{NodeParam, NodeType}
+import zhujiang.ZJParameters
+import zhujiang.device.AxiDeviceParams
+
+object ZhuJiangNoCTopology {
+  def apply(numCores: Int, base: ZJParameters = ZJParameters()): ZJParameters = {
+    apply(numCores, base, base.cfgAxiDataBits)
+  }
+
+  def apply(numCores: Int, base: ZJParameters, cfgAxiDataBits: Int): ZJParameters = {
+    require(numCores == 1 || numCores == 2, "ZhuJiang system config currently supports one or two cores")
+    base.copy(
+      nodeNidBits = 8,
+      nodeAidBits = 3,
+      cfgAxiDataBits = cfgAxiDataBits,
+      nodeParams = if (numCores == 1) singleCoreNodeParams else dualCoreNodeParams,
+      tfbParams = None
+    )
+  }
+
+  private def singleCoreNodeParams: Seq[NodeParam] = Seq(
+    NodeParam(nodeType = NodeType.HF, bankId = 0, hfpId = 0),
+    NodeParam(nodeType = NodeType.CC, socket = "sync"),
+    NodeParam(nodeType = NodeType.HF, bankId = 1, hfpId = 0),
+    NodeParam(nodeType = NodeType.RI, axiDevParams = Some(AxiDeviceParams(wrapper = "east", attr = "main"))),
+    NodeParam(nodeType = NodeType.HI, axiDevParams = Some(AxiDeviceParams(wrapper = "east", attr = "main")), defaultHni = true),
+    NodeParam(nodeType = NodeType.HF, bankId = 1, hfpId = 1),
+    NodeParam(nodeType = NodeType.S, axiDevParams = Some(AxiDeviceParams(wrapper = "south", attr = "mem_0"))),
+    NodeParam(nodeType = NodeType.HF, bankId = 0, hfpId = 1),
+    NodeParam(nodeType = NodeType.M, axiDevParams = Some(AxiDeviceParams(wrapper = "misc", attr = "hwa"))),
+    NodeParam(nodeType = NodeType.P)
+  )
+
+  private def dualCoreNodeParams: Seq[NodeParam] = Seq(
+    NodeParam(nodeType = NodeType.HF, bankId = 0, hfpId = 0),
+    NodeParam(nodeType = NodeType.CC, socket = "sync"),
+    NodeParam(nodeType = NodeType.HF, bankId = 1, hfpId = 0),
+    NodeParam(nodeType = NodeType.CC, socket = "sync"),
+    NodeParam(nodeType = NodeType.RI, axiDevParams = Some(AxiDeviceParams(wrapper = "east", attr = "main"))),
+    NodeParam(nodeType = NodeType.HI, axiDevParams = Some(AxiDeviceParams(wrapper = "east", attr = "main")), defaultHni = true),
+    NodeParam(nodeType = NodeType.HF, bankId = 1, hfpId = 1),
+    NodeParam(nodeType = NodeType.S, axiDevParams = Some(AxiDeviceParams(wrapper = "south", attr = "mem_0"))),
+    NodeParam(nodeType = NodeType.HF, bankId = 0, hfpId = 1),
+    NodeParam(nodeType = NodeType.M, axiDevParams = Some(AxiDeviceParams(wrapper = "misc", attr = "hwa"))),
+    NodeParam(nodeType = NodeType.P)
+  )
+}

--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -26,8 +26,8 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tile.{BusErrorUnit, BusErrorUnitParams, BusErrors, MaxHartIdBits}
 import freechips.rocketchip.tilelink._
-import xscache.coupledL2.{CoupledL2, EnableL2ClockGate, EnableMatrix, L2ParamKey, PrefetchCtrlFromCore}
-import xscache.chi.{CHIIssue, CHIAddrWidthKey, NonSecureKey, PortIO}
+import xscache.coupledL2.{CoupledL2, EnableL2ClockGate, EnableL2DecoupledDownstreamCHI, EnableMatrix, L2ParamKey, PrefetchCtrlFromCore}
+import xscache.chi.{CHIDataCheckKey, CHIIssue, CHIAddrWidthKey, CHIPoisonKey, DecoupledPortIO, NonSecureKey, PortIO}
 import xscache.common.BankBitsKey
 import system.HasSoCParameter
 import top.BusPerfMonitor
@@ -107,7 +107,6 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
   val beu_local_int_source = IntSourceNode(IntSourcePortSimple())
   val beu_local_int_source_buffer = IntBuffer()
 
-  println(s"enableCHI: ${enableCHI}")
   val l2cache = if (enableL2) {
     val config = new Config((_, _, _) => {
       case L2ParamKey => coreParams.L2CacheParamsOpt.get.copy(
@@ -121,6 +120,9 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
       case CHIIssue => p(CHIIssue)
       case CHIAddrWidthKey => p(CHIAddrWidthKey)
       case NonSecureKey => p(NonSecureKey)
+      case CHIDataCheckKey if isZhuJiang => "none"
+      case CHIPoisonKey if isZhuJiang => false
+      case EnableL2DecoupledDownstreamCHI => isZhuJiang
       case BankBitsKey => log2Ceil(coreParams.L2NBanks)
       case MaxHartIdBits => p(MaxHartIdBits)
       case LogUtilsOptionsKey => p(LogUtilsOptionsKey)
@@ -222,8 +224,14 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
         val fromTile = Input(ValidIO(UInt(64.W)))
         val toCore = Output(ValidIO(UInt(64.W)))
       }
-      val chi = if (enableCHI) Some(new PortIO) else None
-      val nodeID = if (enableCHI) Some(Input(UInt(NodeIDWidth.W))) else None
+      val chi = Option.when(isOpenLLC)(new PortIO)
+      val decoupledCHI = Option.when(isZhuJiang)(
+        new DecoupledPortIO()(p.alter((_, _, _) => {
+          case CHIDataCheckKey => "none"
+          case CHIPoisonKey => false
+        }))
+      )
+      val nodeID = Some(Input(UInt(NodeIDWidth.W)))
       val pfCtrlFromCore = Input(new PrefetchCtrlFromCore)
       val l2_tlb_req = new TlbRequestIO(nRespDups = 2)
       val l2_pmp_resp = Flipped(new PMPRespBundle)
@@ -296,7 +304,8 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
     dontTouch(io.hartId)
     dontTouch(io.cpu_halt)
     dontTouch(io.cpu_critical_error)
-    if (!io.chi.isEmpty) { dontTouch(io.chi.get) }
+    io.chi.foreach(dontTouch(_))
+    io.decoupledCHI.foreach(dontTouch(_))
 
     // Initialize matrixDataOut512L2 with zero
     io.matrixDataOut512L2.foreach { data =>
@@ -358,7 +367,11 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
       l2.io.l2_tlb_req.pmp_resp.mmio := io.l2_pmp_resp.mmio
       l2.io.l2_tlb_req.pmp_resp.atomic := io.l2_pmp_resp.atomic
       l2.io.nodeID := io.nodeID.get
-      io.chi.get <> l2.io.chi
+      if (isOpenLLC) {
+        io.chi.get <> l2.io.lcreditCHI.get
+      } else {
+        io.decoupledCHI.get <> l2.io.decoupledCHI.get
+      }
       l2.io.cpu_wfi.foreach { _ := io.cpu_halt.fromCore }
       l2.io.matrixDataOut.foreach { matrixDataOut =>
         io.matrixDataOut512L2 <> matrixDataOut

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -28,7 +28,7 @@ import system.HasSoCParameter
 import top.{ArgParser, BusPerfMonitor, Generator}
 import utility._
 import utility.sram.SramBroadcastBundle
-import xscache.chi.PortIO
+import xscache.chi.{CHIDataCheckKey, CHIPoisonKey, DecoupledPortIO, PortIO}
 import xiangshan.backend.trace.TraceCoreInterface
 import xiangshan.backend.fu.matrix._
 import xiangshan.backend.fu.matrix.Bundles._
@@ -57,7 +57,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
   val enableL2 = coreParams.L2CacheParamsOpt.isDefined
   // =========== Public Ports ============
   val memBlock = core.memBlock.inner
-  val memory_port = if (enableL2) None else Some(l2top.inner.memory_port.get)
+  val memory_port = None
   val tl_uncache = l2top.inner.mmio_port
   val sep_tl_opt = l2top.inner.sep_tl_port_opt
   val beu_int_source = l2top.inner.beu.intNode
@@ -134,8 +134,14 @@ class XSTile()(implicit p: Parameters) extends LazyModule
         val l3MissMatch = Input(Bool())
       }
       val l3Miss = Input(Bool())
-      val chi = if (enableCHI) Some(new PortIO) else None
-      val nodeID = if (enableCHI) Some(Input(UInt(NodeIDWidth.W))) else None
+      val chi = Option.when(isOpenLLC)(new PortIO)
+      val decoupledCHI = Option.when(isZhuJiang)(
+        new DecoupledPortIO()(p.alter((_, _, _) => {
+          case CHIDataCheckKey => "none"
+          case CHIPoisonKey => false
+        }))
+      )
+      val nodeID = Some(Input(UInt(NodeIDWidth.W)))
       val clintTime = Input(ValidIO(UInt(64.W)))
       val dft = Option.when(hasDFT)(Input(new SramBroadcastBundle))
       val dft_reset = Option.when(hasMbist)(Input(new DFTResetSignals()))
@@ -146,7 +152,8 @@ class XSTile()(implicit p: Parameters) extends LazyModule
     dontTouch(io.hartId)
     dontTouch(io.msiInfo)
     io.teemsiInfo.foreach(dontTouch(_))
-    if (!io.chi.isEmpty) { dontTouch(io.chi.get) }
+    io.chi.foreach(dontTouch(_))
+    io.decoupledCHI.foreach(dontTouch(_))
 
     val core_soft_rst = core_reset_sink.in.head._1 // unused
 
@@ -239,6 +246,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
     core.module.io.topDownInfo.l3Miss := l2top.module.io.l3Miss.toCore
 
     io.chi.foreach(_ <> l2top.module.io.chi.get)
+    io.decoupledCHI.foreach(_ <> l2top.module.io.decoupledCHI.get)
     l2top.module.io.nodeID.foreach(_ := io.nodeID.get)
 
     if (debugOpts.ResetGen && enableL2) {

--- a/src/main/scala/xiangshan/XSTileWrap.scala
+++ b/src/main/scala/xiangshan/XSTileWrap.scala
@@ -25,7 +25,7 @@ import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 import system.HasSoCParameter
-import xscache.chi.{AsyncPortIO, CHIAsyncBridgeSource, PortIO}
+import xscache.chi.{AsyncPortIO, CHIAsyncBridgeSource, CHIDataCheckKey, CHIPoisonKey, DecoupledPortIO, PortIO}
 import utility.sram.SramBroadcastBundle
 import utility.{DFTResetSignals, IntBuffer, ResetGen}
 import xiangshan.backend.trace.TraceCoreInterface
@@ -87,11 +87,17 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
         val l3MissMatch = Input(Bool())
       }
       val l3Miss = Input(Bool())
-      val chi = EnableCHIAsyncBridge match {
+      val chi = Option.when(isOpenLLC)(EnableCHIAsyncBridge match {
         case Some(param) => new AsyncPortIO(param)
         case None => new PortIO
-      }
-      val nodeID = if (enableCHI) Some(Input(UInt(NodeIDWidth.W))) else None
+      })
+      val decoupledCHI = Option.when(isZhuJiang)(
+        new DecoupledPortIO()(p.alter((_, _, _) => {
+          case CHIDataCheckKey => "none"
+          case CHIPoisonKey => false
+        }))
+      )
+      val nodeID = Some(Input(UInt(NodeIDWidth.W)))
       val clintTime = EnableClintAsyncBridge match {
         case Some(param) => Flipped(new AsyncBundle(UInt(64.W), param))
         case None => Input(ValidIO(UInt(64.W)))
@@ -183,14 +189,18 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
     }
 
     // CHI Async Queue Source
-    EnableCHIAsyncBridge match {
-      case Some(param) =>
-        val source = withClockAndReset(clock, reset_sync)(Module(new CHIAsyncBridgeSource(param)))
-        source.io.enq <> tile.module.io.chi.get
-        io.chi <> source.io.async
-      case None =>
-        require(enableCHI)
-        io.chi <> tile.module.io.chi.get
+    if (isOpenLLC) {
+      EnableCHIAsyncBridge match {
+        case Some(param) =>
+          val source = withClockAndReset(clock, reset_sync)(Module(new CHIAsyncBridgeSource(param)))
+          source.io.enq <> tile.module.io.chi.get
+          io.chi.get <> source.io.async
+        case None =>
+          io.chi.get <> tile.module.io.chi.get
+      }
+    } else {
+      require(EnableCHIAsyncBridge.isEmpty, "LLC=ZhuJiang does not support async CHI bridge")
+      io.decoupledCHI.get <> tile.module.io.decoupledCHI.get
     }
 
     withClockAndReset(clock, reset_sync) {

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -39,10 +39,6 @@ class XiangShanSim(implicit p: Parameters) extends Module with HasDiffTestInterf
   // so that we can re-use this XiangShanSim for any generated Verilog RTL.
   dontTouch(soc.io)
 
-  if (!l_soc.module.dma.isEmpty) {
-    l_soc.module.dma.get <> WireDefault(0.U.asTypeOf(l_soc.module.dma.get))
-  }
-
   val l_simMMIO = LazyModule(new SimMMIO(l_soc.misc.peripheralNode.in.head._2)(p.alter((site, here, up) => {
     case SoCParamsKey => up(SoCParamsKey).copy(UARTLiteForDTS = false)
   })))


### PR DESCRIPTION
## Purpose

Port the ZhuJiang LLC integration from [OpenXiangShan/XiangShan#6122](https://github.com/OpenXiangShan/XiangShan/pull/6122) to XSAI after the cache subsystem migration from XSCache to XSAICache. This also updates the XSAICache gitlink to its existing feat-zhujiang branch.

## Changes

- Add an LLC selector for OpenLLC and ZhuJiang, with ZhuJiang as the default.
- Add CLI and YAML configuration for the LLC type, cache capacity, associativity, and supported ZhuJiang constraints.
- Compile ZhuJiang, xs-utils, and the XSAICache ZhuJiang bridge through the XSAI Mill build.
- Add one-core and two-core ZhuJiang NoC topologies using the XSAI external AXI bus width.
- Propagate the Decoupled CHI interface through CoupledL2, XSTile, XSTileWrap, and XSTop while retaining the L-credit CHI path for OpenLLC.
- Connect ZhuJiang CC, DDR AXI, and configuration AXI ports and tie off unused DMA, HWA, and extra DDR ports.
- Restrict XSNoCTop to OpenLLC and keep the existing XSAI Matrix configuration and interfaces.
- Update make init to initialize the nested ZhuJiang submodule.

## Validation

- make init
- make check-format
- make comp
- NOOP_HOME=/nfs/home/chenxi/xsai-env/XSAI make sim-verilog CONFIG=DefaultMatrixConfig NUM_CORES=1 ISSUE=E.b LLC=ZhuJiang
- Confirmed non-empty build/rtl/SimTop.sv and build/rtl/SimTop.sv.conf outputs.
- Confirmed ZhuJiang elaboration with nodeIdBits=11, dataBits=256, and dataCheckBits=0.