### PR TITLE
refactor(cute): align msync configuration with core parameters

### DIFF
--- a/src/main/scala/cutewrapper/XSCuteTop.scala
+++ b/src/main/scala/cutewrapper/XSCuteTop.scala
@@ -154,6 +154,8 @@ class XSCuteImp(wrapper: XSCute)(implicit p: Parameters) extends LazyModuleImp(w
   with HasXSParameter 
   with CUTEImplParameters
 {
+    require(MsyncRegs == CuteMsyncRegs, s"core MsyncRegs ($MsyncRegs) must match CUTE MsyncRegs ($CuteMsyncRegs)")
+
     wrapper.node.zipWithIndex.foreach { case (node, i) =>
       (node.in zip node.out).foreach { case ((in, edgeIn), (out, edgeOut)) =>
         out <> in

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -278,6 +278,7 @@ class MinimalMatrixConfig(n: Int) extends Config(
       val cuteBase = CuteParams.CUTE_2Tops
       val (tensorMn, tensorK) = MatrixCuteTensorDims.fromXcore(xp)
       cuteBase.copy(
+        MsyncRegs = xp.MsyncRegs,
         Tensor_MN = tensorMn,
         Tensor_K = tensorK,
         Debug = CuteDebugParams.NoDebug,
@@ -514,6 +515,7 @@ class DefaultMatrixConfig(n: Int = 1) extends Config(
       val cuteBase = CuteParams.CUTE_8Tops_128SCP
       val (tensorMn, tensorK) = MatrixCuteTensorDims.fromXcore(xp)
       cuteBase.copy(
+        MsyncRegs = xp.MsyncRegs,
         Tensor_MN = tensorMn,
         Tensor_K = tensorK,
         Debug = CuteDebugParams.NoDebug,

--- a/src/main/scala/xiangshan/backend/fu/matrix/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/fu/matrix/Bundles.scala
@@ -153,7 +153,7 @@ object Bundles {
   }
 
   class AmuReleaseIO2CUTE(implicit p: Parameters) extends XSBundle {
-    val msyncRd = UInt(p(XSCoreParamsKey).MsyncRegs.W)
+    val msyncRd = UInt(log2Ceil(p(XSCoreParamsKey).MsyncRegs).W)
   }
 
   object AmuReleaseIO2CUTE {


### PR DESCRIPTION
- parameterized msync support in CUTE
- pass the core msync count into minimal and default CUTE configurations